### PR TITLE
Fix links in HTML & README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Looking for a basic website template that includes Hack Club's theme CSS? Look n
 This is a blank repository all set up for you to start your own website. We include [Hack Club's theme](https://css.hackclub.com/) [CSS](theme.css) for you to use if you wish.
 
 1. [Create a copy](https://github.com/hackclub/css-starter/generate) of this template repository and name it `css-starter`
-1. Download or clone your new repository by clicking the green `Code` button 
+1. Download or clone your new repository by clicking the green `Code` button
    - For downloading, click `Download Zip`. Drag that file to your desktop, open your terminal, and navigate to the file in your terminal:
       - Mac: `cd ~/Desktop/css-starter`
       - Windows: `cd C:\Users\%USERNAME%\Desktop\css-starter`
@@ -32,9 +32,9 @@ This is a blank repository all set up for you to start your own website. We incl
 ## Theme examples
 
 Want to use our theme but don't know where to start? Check out:
-  - View our theme elements <a href="https://theme.hackclub.com/">here</a>
-  - View our theme documentation <a href="https://github.com/hackclub/css">here</a>
-  - View a static example of a site using our theme <a href="https://github.com/hackclub/contribute">here</a>
+  - View our theme elements [here](https://css.hackclub.com/)
+  - View our theme code and documentation [here](https://github.com/hackclub/css)
+  - View a static example of a site using our theme [here](https://contribute.hackclub.com/) and its code [here](https://github.com/hackclub/contribute)
   - Join the <a href="https://hackclub.com/slack/">Hack Club Slack</a> and ask community members how they're using the theme!
 
 ## Contributing

--- a/index.html
+++ b/index.html
@@ -66,9 +66,9 @@
       <p>Want to use our theme but don't know where to start? Check out:</p>
 
       <ul>
-        <li>View our theme elements <a target="_blank" href="https://theme.hackclub.com/">here</a></li>
+        <li>View our theme elements <a target="_blank" href="https://css.hackclub.com/">here</a></li>
         <li>View our theme documentation <a target="_blank" href="https://github.com/hackclub/css">here</a></li>
-        <li>View a static example of a site using our theme <a target="_blank" href="https://github.com/hackclub/contribute">here</a></li>
+        <li>View a static example of a site using our theme <a target="_blank" href="https://contribute.hackclub.com/">here</a> and its code <a target="_blank" href="https://github.com/hackclub/contribute">here</a></li>
         <li>Join the <a target="_blank" href="https://hackclub.com/slack/">Hack Club Slack</a> and ask community members how they're using the theme!</li>
       </ul>
     </div>

--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
 
       <ul>
         <li>View our theme elements <a target="_blank" href="https://css.hackclub.com/">here</a></li>
-        <li>View our theme documentation <a target="_blank" href="https://github.com/hackclub/css">here</a></li>
+        <li>View our theme code and documentation <a target="_blank" href="https://github.com/hackclub/css">here</a></li>
         <li>View a static example of a site using our theme <a target="_blank" href="https://contribute.hackclub.com/">here</a> and its code <a target="_blank" href="https://github.com/hackclub/contribute">here</a></li>
         <li>Join the <a target="_blank" href="https://hackclub.com/slack/">Hack Club Slack</a> and ask community members how they're using the theme!</li>
       </ul>


### PR DESCRIPTION
We had links pointing to the wrong places.

Fix up links, and change the README to use markdown instead of HTML